### PR TITLE
Refactor `UserStatsReceived` to use C# 10.0 record type

### DIFF
--- a/SAM.API/Callbacks/UserStatsReceived.cs
+++ b/SAM.API/Callbacks/UserStatsReceived.cs
@@ -1,8 +1,8 @@
-﻿using SAM.API.Stats;
+using SAM.API.Stats;
 
 namespace SAM.API
 {
-    public class UserStatsReceived : Callback<UserStatsResponse>
+    public record UserStatsReceived : Callback<UserStatsResponse>
     {
         public override int Id => 1101;
         public override bool IsServer => false;


### PR DESCRIPTION
Changed `UserStatsReceived` from a `class` to a `record` for improved value semantics, providing immutability and structural equality.